### PR TITLE
백엔드 개발 로드맵 문서 정리

### DIFF
--- a/docs/current.md
+++ b/docs/current.md
@@ -1,6 +1,6 @@
 # 현재 작업 컨텍스트
 
-최종 업데이트: 2026-03-31 03:01
+최종 업데이트: 2026-03-31 15:35
 업데이트 주체: Codex
 
 ## 프로젝트 상태
@@ -23,6 +23,7 @@
 - **리뷰 루프 제한**: 같은 파일/같은 task에서 reviewer 수정 루프는 최대 2회까지만 반복하고, 이후에는 blocking 이슈만 추가 수정한 뒤 다음 단계로 진행한다.
 - **리뷰 기준**: Windows/Linux/Unix 환경 차이에서만 생기는 인코딩, 개행 문자, 실행 비트 차이는 무시하고 실제 코드 동작 변경만 검토한다.
 - **GitHub 파이프라인**: 신규 작업은 `gh` 기반 한국어 issue 생성 → `codex/<issue-number>-brief-slug` 브랜치 작업 → 한국어 PR → `main` merge → issue/PR/브랜치 정리 순서로 진행한다.
+- **개발 로드맵**: [issue #1](https://github.com/earlydreamer/sora-backend/issues/1) 기준으로 `docs/superpowers/plans/2026-03-31-backend-development-roadmap.md`에 다음 개발 순서를 정리했다.
 
 ## 하네스 상태
 - 상태: done
@@ -35,6 +36,7 @@
 ### 진행 중
 - [ ] Supabase 프로젝트 생성 후 DATABASE_URL 발급 (담당: 사람)
 - [ ] TMAP API 키 발급 (담당: 사람)
+- [ ] 외부 리소스 준비 완료 후 활성 구현 스펙 생성 (담당: Codex)
 
 ### 대기 중 (블로커 있음)
 - [ ] `npx prisma migrate dev --name init` 실행 — 블로커: DATABASE_URL 미설정
@@ -43,6 +45,7 @@
 - [ ] GitHub Actions heartbeat 설정 (Supabase 7일 비활성 방지) — 블로커: Supabase 프로젝트 생성 선행
 
 ### 완료
+- [x] 백엔드 개발 작업 목록과 우선순위 문서화
 - [x] gstack 전역 설치 및 운영 문서화
 - [x] NestJS scaffold (Prisma 7, TypeScript, ESLint)
 - [x] 의존성 설치 (JWT, bcrypt, Prisma, class-validator 등)

--- a/docs/history/2026-03-31-backend-development-task-list.md
+++ b/docs/history/2026-03-31-backend-development-task-list.md
@@ -1,0 +1,23 @@
+# 백엔드 개발 작업 목록 정리
+
+날짜: 2026-03-31
+작업자: Codex
+
+## 작업 범위
+현재 백엔드 개발에 필요한 후속 작업을 우선순위와 블로커 기준으로 정리했다.
+
+## 변경 내용
+- 외부 리소스 준비, DB 초기화, TMAP 실제 좌표 연동, Railway 배포, 운영 자동화 순으로 개발 로드맵을 정리했다.
+- `docs/superpowers/plans/2026-03-31-backend-development-roadmap.md`에 다음 구현 순서를 문서화했다.
+- `docs/current.md`에 즉시 실행할 다음 단계와 완료된 계획 정리 작업을 반영했다.
+
+## 결정 사항
+- 다음 구현 착수 전 선행 블로커는 `DATABASE_URL`과 `TMAP_API_KEY` 확보로 고정한다.
+- 구현 순서는 `환경 준비 → Prisma migrate → TMAP 실제 좌표 연동 → Railway 배포 → heartbeat 자동화`로 진행한다.
+- 활성 구현 스펙은 아직 만들지 않고, 외부 리소스 준비가 끝난 뒤 `/start-harness 활성 스펙 기준 구현`으로 이어간다.
+
+## 다음 스텝
+- Supabase 프로젝트 생성 후 `DATABASE_URL`을 `.env`에 반영
+- TMAP API 키 발급
+- `npx prisma migrate dev --name init` 실행
+- 활성 구현 스펙 생성 후 실제 코드 작업 시작

--- a/docs/superpowers/plans/2026-03-31-backend-development-roadmap.md
+++ b/docs/superpowers/plans/2026-03-31-backend-development-roadmap.md
@@ -1,0 +1,278 @@
+# Sora Backend Development Roadmap Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 외부 의존성 준비부터 실제 대중교통 연동과 배포까지, 백엔드가 실사용 가능한 상태로 이어지는 후속 개발 작업을 우선순위대로 정리한다.
+
+**Architecture:** 현재 NestJS 모듈 구조와 Prisma 스키마를 유지한 채, 외부 리소스 준비를 선행하고 그 위에 DB 초기화, TMAP 실제 좌표 연동, 배포/운영 자동화를 순차적으로 쌓는다. 각 단계는 이전 단계의 블로커를 해소하는 방식으로 구성해 구현 순서가 문서만 봐도 드러나도록 한다.
+
+**Tech Stack:** NestJS, Prisma 7, Supabase PostgreSQL, TMAP API, Railway, GitHub Actions
+
+---
+
+### Task 1: 외부 리소스와 로컬 환경 준비
+
+**Files:**
+- Modify: `README.md`
+- Modify: `docs/current.md`
+- Reference: `.env.example`
+
+- [ ] **Step 1: Supabase 프로젝트를 생성하고 연결 문자열을 확보한다**
+
+Run:
+
+```bash
+cp .env.example .env
+```
+
+Expected:
+
+```text
+.env 파일이 생성되고 DATABASE_URL 입력 위치를 확인할 수 있다.
+```
+
+- [ ] **Step 2: `.env`에 `DATABASE_URL`, `JWT_SECRET`, `TMAP_API_KEY`를 채운다**
+
+Check:
+
+```bash
+rg -n "DATABASE_URL|JWT_SECRET|TMAP_API_KEY" .env .env.example
+```
+
+Expected:
+
+```text
+.env.example의 키와 동일한 항목이 .env에 존재한다.
+```
+
+- [ ] **Step 3: 작업 상태판을 현재 리소스 준비 상태로 갱신한다**
+
+Modify:
+
+```md
+- [ ] Supabase 프로젝트 생성 후 DATABASE_URL 발급
+- [ ] TMAP API 키 발급
+```
+
+Expected:
+
+```text
+docs/current.md의 진행/대기 상태가 실제 준비 상태와 일치한다.
+```
+
+### Task 2: Prisma 초기화와 기본 검증
+
+**Files:**
+- Modify: `prisma/schema.prisma`
+- Modify: `README.md`
+- Modify: `docs/current.md`
+- Create: `prisma/migrations/<timestamp>_init/*`
+
+- [ ] **Step 1: Prisma client를 다시 생성한다**
+
+Run:
+
+```bash
+npx prisma generate
+```
+
+Expected:
+
+```text
+Prisma Client generated
+```
+
+- [ ] **Step 2: 첫 migration을 생성한다**
+
+Run:
+
+```bash
+npx prisma migrate dev --name init
+```
+
+Expected:
+
+```text
+Applying migration `..._init`
+```
+
+- [ ] **Step 3: 저장소 기본 검증을 수행한다**
+
+Run:
+
+```bash
+npm run build
+npm run lint
+CI=1 npm test -- --runInBand
+CI=1 npm run test:e2e -- --runInBand
+```
+
+Expected:
+
+```text
+모든 명령이 성공하고 현재 스캐폴드 기준 테스트가 유지된다.
+```
+
+### Task 3: TMAP 실제 좌표 연동 완성
+
+**Files:**
+- Modify: `src/transit/transit.service.ts`
+- Modify: `src/transit/transit.controller.ts`
+- Modify: `README.md`
+- Test: `test/app.e2e-spec.ts`
+
+- [ ] **Step 1: 주소 입력값을 TMAP 좌표로 변환하는 흐름을 설계한다**
+
+Check:
+
+```bash
+sed -n '1,220p' src/transit/transit.service.ts
+```
+
+Expected:
+
+```text
+현재 TODO로 남아 있는 geocoding 좌표 변환 지점을 확인한다.
+```
+
+- [ ] **Step 2: origin/destination을 좌표로 바꾼 뒤 ETA 호출에 연결한다**
+
+Implement target:
+
+```ts
+// origin, destination 주소를 geocoding 후 startX/startY/endX/endY에 연결
+```
+
+Expected:
+
+```text
+TMAP ETA 요청이 하드코딩 없는 실제 좌표 기반으로 동작한다.
+```
+
+- [ ] **Step 3: 예외 처리와 회귀 검증을 추가한다**
+
+Run:
+
+```bash
+npm run build
+npm run lint
+CI=1 npm test -- --runInBand
+CI=1 npm run test:e2e -- --runInBand
+```
+
+Expected:
+
+```text
+TMAP 키 누락, 응답 실패, 타임아웃 방어가 기존 계약을 깨지 않는다.
+```
+
+### Task 4: Railway 배포 연결
+
+**Files:**
+- Modify: `README.md`
+- Modify: `docs/current.md`
+- Modify: 필요 시 `package.json`
+
+- [ ] **Step 1: Railway 프로젝트를 생성하고 환경변수를 동기화한다**
+
+Required vars:
+
+```text
+DATABASE_URL
+JWT_SECRET
+TMAP_API_KEY
+PORT
+```
+
+Expected:
+
+```text
+로컬과 Railway에서 동일한 런타임 설정을 사용할 수 있다.
+```
+
+- [ ] **Step 2: 배포 후 healthcheck를 검증한다**
+
+Run:
+
+```bash
+curl <railway-url>/
+```
+
+Expected:
+
+```json
+{"status":"ok"}
+```
+
+- [ ] **Step 3: 주요 API smoke test를 수행한다**
+
+Check endpoints:
+
+```text
+POST /auth/register
+POST /auth/login
+GET /routes
+GET /transit/eta
+```
+
+Expected:
+
+```text
+인증, 기본 데이터 접근, ETA 계산 경로가 배포 환경에서도 응답한다.
+```
+
+### Task 5: 운영 자동화와 후속 안정화
+
+**Files:**
+- Modify: `.github/workflows/<heartbeat>.yml`
+- Modify: `docs/current.md`
+- Modify: `README.md`
+- Create: `docs/history/2026-03-31-backend-development-task-list.md`
+
+- [ ] **Step 1: Supabase 비활성 방지 heartbeat를 추가한다**
+
+Implement target:
+
+```yaml
+on:
+  schedule:
+    - cron: '0 0 * * *'
+```
+
+Expected:
+
+```text
+7일 비활성으로 인한 DB sleep 위험을 줄인다.
+```
+
+- [ ] **Step 2: 운영 문서와 현재 상태판을 최신화한다**
+
+Update targets:
+
+```text
+docs/current.md
+README.md
+docs/history/*
+```
+
+Expected:
+
+```text
+새 에이전트가 현재 배포/운영 상태를 문서만 보고 이어받을 수 있다.
+```
+
+- [ ] **Step 3: 다음 우선순위 구현 후보를 재평가한다**
+
+Review list:
+
+```text
+주소 autocomplete
+출발 기록 UX 지원 API
+운영 모니터링
+```
+
+Expected:
+
+```text
+Phase 2 이후 backlog가 활성 스펙 후보 수준으로 정리된다.
+```


### PR DESCRIPTION
## 요약
- 백엔드 개발 작업 목록 history와 후속 구현 로드맵 plan을 브랜치에 정식 반영했다.
- `docs/current.md`에 다음 개발 순서와 활성 구현 스펙 대기 상태를 연결했다.
- 이 작업은 문서 전용 작업으로 관리한다.

## 검증
- [x] 문서 링크, 경로, 계획 문서 참조 정합성 확인
- [ ] `npm run build`
  docs-only 예외 적용으로 비대상
- [ ] `npm run lint`
  docs-only 예외 적용으로 비대상
- [ ] `CI=1 npm test -- --runInBand`
  docs-only 예외 적용으로 비대상
- [ ] `CI=1 npm run test:e2e -- --runInBand`
  docs-only 예외 적용으로 비대상

## 연결 이슈
- Closes #1
