### PR TITLE
GUI 히스토리용 non-squash merge 정책 명시

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,6 +162,8 @@ Claude가 Codex에 작업을 넘길 때는 아래 형식으로 작업 범위를 
 - 작업은 issue에 연결된 브랜치에서만 진행한다.
 - 검증이 모두 통과하기 전에는 PR merge를 진행하지 않는다.
 - 단, `docs-only` 작업은 문서 링크, 경로, 문서 간 정합성 확인이 끝나면 merge 가능 상태로 본다.
+- Fork 같은 GUI Git 클라이언트에서 `main` 히스토리를 눈으로 추적할 수 있어야 하므로, 기본 merge 전략은 의미 단위 커밋을 보존하는 non-squash를 사용한다.
+- squash merge는 기본값으로 사용하지 않는다. 사용자 요청이 있거나, fixup-only 성격의 브랜치를 의도적으로 접어야 하는 예외 상황에서만 사용한다.
 - merge 완료 후 issue, PR, 로컬 브랜치, 원격 브랜치가 남아 있으면 작업 완료로 간주하지 않는다.
 - merge 완료 후에는 사용자가 실제로 작업을 이어갈 로컬 작업 디렉터리가 최종 기준 브랜치를 가리키는지 확인해야 한다. 이 단계가 빠지면 다른 LLM handoff 기준으로는 완료가 아니다.
 - GitHub 작업 절차 상세는 [docs/operations/github-task-pipeline.md](./docs/operations/github-task-pipeline.md)를 따른다.

--- a/docs/current.md
+++ b/docs/current.md
@@ -1,11 +1,11 @@
 # 현재 작업 컨텍스트
 
-최종 업데이트: 2026-04-01 00:27
+최종 업데이트: 2026-04-01 13:38
 업데이트 주체: Codex
 
 ## 프로젝트 상태
 
-`start-harness` 트리거 구조와 tmux 오케스트레이션 계약 정비를 완료했고, 실제 tmux Codex worker가 격리 runtime home으로 안정적으로 동작함을 재검증했다. 기존 백엔드 scaffold는 유지되며, 하네스 문서/skill/스크립트/테스트가 같은 해석으로 동작한다.
+`start-harness` 트리거 구조와 tmux 오케스트레이션 계약 정비를 완료한 상태를 유지하면서, GUI 히스토리 추적 관점을 반영한 non-squash merge 기본 정책까지 운영 문서에 반영했다.
 
 ## 활성 컨텍스트
 
@@ -23,11 +23,12 @@
 - **리뷰 루프 제한**: 같은 파일/같은 task에서 reviewer 수정 루프는 최대 2회까지만 반복하고, 이후에는 blocking 이슈만 추가 수정한 뒤 다음 단계로 진행한다.
 - **리뷰 기준**: Windows/Linux/Unix 환경 차이에서만 생기는 인코딩, 개행 문자, 실행 비트 차이는 무시하고 실제 코드 동작 변경만 검토한다.
 - **GitHub 파이프라인**: 신규 작업은 `gh` 기반 한국어 issue 생성 → `codex/<issue-number>-brief-slug` 브랜치 작업 → 한국어 PR → `main` merge → issue/PR/브랜치 정리 순서로 진행한다.
+- **merge 정책**: Fork 같은 GUI Git 클라이언트에서 `main` 히스토리를 바로 추적할 수 있어야 하므로 기본 merge 전략은 non-squash이며, squash는 예외 상황에서만 사용한다.
 - **개발 로드맵**: [issue #1](https://github.com/earlydreamer/sora-backend/issues/1) 기준으로 `docs/superpowers/plans/2026-03-31-backend-development-roadmap.md`에 다음 개발 순서를 정리했다.
 - **codex-plugin-cc**: `HAS_CODEX_PLUGIN` probe 변수 추가. 플러그인 설치 후 tmux 없이도 실제 Codex CLI 위임 가능 (tier 2). 설치: `/plugin marketplace add openai/codex-plugin-cc` → `/plugin install codex@openai-codex` → `/reload-plugins` → `/codex:setup`
 - **tmux 오케스트레이션**: 1~5단계 완료. helper script (`spawn-worker`, `list-workers`, `capture-worker`, `mark-worker`, `recover-session`, `dashboard`, `enqueue-worker`)를 `scripts/orchestrator/`에 구현. 4단계에서 TUI 상태판(`dashboard`), 우선순위 큐(`enqueue-worker`), pane 기반 로그(`--split-log`), 자동 재시도(`--retry N`) 추가.
 - **tmux Codex runtime isolation**: `spawn-worker`는 Codex worker마다 `.orchestrator/runtime/codex-home/<worker-id>`를 준비해 `CODEX_HOME`을 격리한다. 실제 tmux live smoke에서 `TMUX_ISOLATED_OK`, `HAS_LOGS_IO_ERROR=0`, `HAS_STATE_WARNING=0`을 확인했다.
-- **최근 완료 task**: GitHub issue #19 / branch `codex/19-start-harness-orchestration-hardening`
+- **최근 완료 task**: GitHub issue #21 / branch `codex/21-visible-history-merge-policy`
 - **이번 정비 결과**: `start-harness`를 thin trigger + downstream ownership 구조로 재정의하고, 설치본 skill pack과 backend tmux helper script/test 계약을 일치시켰다.
 - **GitHub 게이트 원칙**: `1 작업 = 1 이슈 = 1 브랜치 = 1 PR` 구조는 유지하되, `gh` hard gate는 실제 tracked task 생성/PR/merge 단계에서만 강제한다.
 - **분산 책임 명시**: Verify/Correct는 `start-harness`가 직접 수행하는 것이 아니라 gstack, superpowers, repo verification, tmux helper script가 나눠 맡는다.
@@ -54,6 +55,7 @@
 - [ ] GitHub Actions heartbeat 설정 (Supabase 7일 비활성 방지) — 블로커: Supabase 프로젝트 생성 선행
 
 ### 완료
+- [x] GUI 히스토리 추적을 위한 non-squash merge 정책을 backend 문서에 반영
 - [x] 백엔드 개발 작업 목록과 우선순위 문서화
 - [x] gstack 전역 설치 및 운영 문서화
 - [x] NestJS scaffold (Prisma 7, TypeScript, ESLint)

--- a/docs/operations/github-task-pipeline.md
+++ b/docs/operations/github-task-pipeline.md
@@ -103,10 +103,18 @@ git diff -- docs/<target>.md
 
 1. 검증 통과 후 PR을 `main`에 merge한다.
    `docs-only` 작업은 문서 무결성 확인 완료를 검증 통과로 본다.
+   기본 merge 전략은 non-squash다.
 2. merge 뒤 PR이 `merged` 상태인지 확인한다.
 3. issue가 닫혔는지 확인한다. 자동으로 닫히지 않았다면 즉시 닫는다.
 4. 로컬 브랜치와 원격 브랜치를 삭제한다.
 5. issue, PR, 브랜치가 하나라도 남아 있으면 작업 완료로 간주하지 않는다.
+
+### 히스토리 가시성 원칙
+
+- Fork 같은 GUI Git 클라이언트에서 `main` 히스토리를 눈으로 따라갈 수 있어야 한다.
+- 따라서 의미 단위 커밋이 `main`에서 바로 보이도록 squash merge를 기본값으로 사용하지 않는다.
+- 기본 전략은 `merge`이며, 저장소 정책이나 사용자 요청이 따로 있을 때만 다른 전략을 쓴다.
+- squash는 사용자가 명시적으로 요청했거나, fixup-only 브랜치를 하나로 접는 것이 더 적절한 예외 상황에서만 사용한다.
 
 ## 권장 명령 예시
 
@@ -117,7 +125,7 @@ git switch main
 git pull --ff-only origin main
 git switch -c codex/<issue-number>-brief-slug
 gh pr create
-gh pr merge --squash --delete-branch
+gh pr merge --merge --delete-branch
 gh issue close <issue-number>
 git branch -d codex/<issue-number>-brief-slug
 ```

--- a/docs/tasks/2026-04-01-visible-history-merge-policy.md
+++ b/docs/tasks/2026-04-01-visible-history-merge-policy.md
@@ -1,0 +1,35 @@
+# Codex 위임 작업
+
+## Codex 위임 작업
+
+**상태**: done
+**출처**: direct-to-codex intake
+**목표**: GUI 히스토리 추적 관점을 반영해 non-squash merge 기본 정책을 backend 운영 문서에 명시한다.
+
+**배경**:
+- Fork 같은 GUI Git 클라이언트에서 `main` 히스토리를 직접 따라가며 작업 맥락을 추적한다.
+- squash merge를 기본값으로 두면 의미 단위 커밋이 `main`에 바로 보이지 않아 handoff와 추적 비용이 커진다.
+
+**수정 대상 파일**:
+- `AGENTS.md` — merge 규칙에 GUI 히스토리 가시성과 squash 지양 원칙을 명시한다.
+- `docs/operations/github-task-pipeline.md` — merge 전략 기본값과 예외 조건을 문서화한다.
+- `docs/current.md` — 필요 시 현재 운영 원칙 요약을 최신화한다.
+
+**비범위**:
+- 코드 동작 변경
+- CI 구성 변경
+- 기존 merge된 커밋 히스토리 재작성
+
+**완료 조건**:
+- [x] `rg -n "squash|GUI|Fork|merge 전략" AGENTS.md docs/operations/github-task-pipeline.md docs/current.md`
+- [x] `git diff -- AGENTS.md docs/operations/github-task-pipeline.md docs/current.md docs/tasks/2026-04-01-visible-history-merge-policy.md`
+- [x] 문서 간 merge 정책 표현이 충돌하지 않는다.
+
+**Claude 재호출 조건**:
+- merge 정책을 저장소별로 다르게 가져가야 한다는 결정이 새로 필요할 때
+- 문서 수정 범위를 넘어 GitHub 자동화나 브랜치 전략 자체를 바꿔야 할 때
+- 다른 저장소와의 통합 정책 결정이 필요할 때
+
+**참고**:
+- GitHub issue #21
+- GUI 클라이언트 기준 추적성 요구


### PR DESCRIPTION
## 요약
- Fork 같은 GUI Git 클라이언트 기준으로 `main` 히스토리 가시성을 merge 정책에 명시했다.
- backend 운영 문서와 current/spec를 non-squash 기본 전략으로 정렬했다.

## 검증
- [x] `rg -n "squash|GUI|Fork|merge 전략|non-squash" AGENTS.md docs/operations/github-task-pipeline.md docs/current.md docs/tasks/2026-04-01-visible-history-merge-policy.md`
- [x] `git diff -- AGENTS.md docs/operations/github-task-pipeline.md docs/current.md docs/tasks/2026-04-01-visible-history-merge-policy.md`
- [x] 문서 간 규칙 충돌 없음 확인

## 연결 이슈
- Closes #21


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Documentation**
  * 기본 병합 전략을 non-squash로 명시하여 GUI 기반 Git 클라이언트에서 메인 히스토리 추적 기능을 지원합니다.
  * Squash 병합은 사용자 요청이나 특정 예외 상황(fixup 전용 브랜치 등)에서만 사용하도록 정책화했습니다.
  * 관련 운영 문서를 업데이트하여 병합 정책 변경 사항을 반영했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->